### PR TITLE
Avoid floating point conversion of given numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OrderOptimizer Gem Changelog
 
+## 0.4.1 (2021-02-15)
+
+- Fix issue with floating point conversion [#3]
+
 ## 0.4.0 (2020-12-11)
 
 - Add `possible_orders` method to find all possible orders
@@ -18,3 +22,5 @@
 - Add support for discounts when ordering a minimum quantity
 
 ## 0.1.0 First release
+
+[#3]: https://github.com/zaikio/order_optimizer/pull/3

--- a/lib/order_optimizer.rb
+++ b/lib/order_optimizer.rb
@@ -56,7 +56,7 @@ class OrderOptimizer
     count, remainder = quantity.divmod(sku.quantity)
 
     if sku.min_quantity && count * sku.quantity < sku.min_quantity
-      new_count = (sku.min_quantity.to_f / sku.quantity).ceil
+      new_count = (sku.min_quantity / sku.quantity).ceil
       remainder -= (new_count - count) * sku.quantity
       [new_count, [remainder, 0].max]
     else

--- a/lib/order_optimizer/sku.rb
+++ b/lib/order_optimizer/sku.rb
@@ -4,18 +4,18 @@ class OrderOptimizer
 
     def initialize(id, quantity:, price_per_sku: nil, price_per_unit: nil, min_quantity: nil)
       @id = id
-      @quantity = quantity
-      @min_quantity = min_quantity
-
-      @price_per_unit = BigDecimal(price_per_unit, 2) if price_per_unit
-      @price_per_sku  = BigDecimal(price_per_sku,  2) if price_per_sku
+      @quantity = BigDecimal(quantity, 2)
+      @min_quantity = BigDecimal(min_quantity, 2) if min_quantity
 
       unless price_per_unit || price_per_sku
         raise ':price_per_sku or :price_per_unit must be set'
       end
 
-      @price_per_unit ||= price_per_sku.to_f / quantity
-      @price_per_sku  ||= quantity * price_per_unit
+      @price_per_unit = BigDecimal(price_per_unit, 2) if price_per_unit
+      @price_per_unit ||= BigDecimal(price_per_sku, 2) / quantity
+
+      @price_per_sku = BigDecimal(price_per_sku,  2) if price_per_sku
+      @price_per_sku ||= quantity * price_per_unit
     end
   end
 end

--- a/lib/order_optimizer/version.rb
+++ b/lib/order_optimizer/version.rb
@@ -1,3 +1,3 @@
 class OrderOptimizer
-  VERSION = "0.4.0"
+  VERSION = "0.4.1".freeze
 end

--- a/test/order_optimizer_test.rb
+++ b/test/order_optimizer_test.rb
@@ -254,4 +254,22 @@ class OrderOptimizerTest < Minitest::Test
     orders = optimizer.possible_orders(required_qty: 946)
     assert_equal 15, orders.count
   end
+
+  def test_that_it_does_not_have_floating_point_issues
+    optimizer = OrderOptimizer.new(
+      '1-pack' => { quantity: BigDecimal("715.392"),
+                    min_quantity: BigDecimal("715.392"),
+                    price_per_unit: 1 },
+    )
+    order, = optimizer.possible_orders(required_qty: 1)
+    assert_equal({ '1-pack' => 1 }, order.skus)
+
+    optimizer = OrderOptimizer.new(
+      '1-pack' => { quantity: 101,
+                    min_quantity: 100,
+                    price_per_unit: 1 },
+    )
+    order, = optimizer.possible_orders(required_qty: 1)
+    assert_equal({ '1-pack' => 1 }, order.skus)
+  end
 end


### PR DESCRIPTION
Floating point issues can cause subtle off-by-one errors. In this case, casting `sku.min_quantity` to a Float caused a loss of precision, so [this calculation](https://github.com/zaikio/order_optimizer/blob/49114aca909b900bdaf74ab59cf459da57ea8855/lib/order_optimizer.rb#L59):

```ruby
sku.min_quantity = BigDecimal("715.392")
sku.quantity     = BigDecimal("715.392") # same!

new_count = (sku.min_quantity.to_f / sku.quantity).ceil
```

Should have returned `1` (because we're dividing the number by itself) but instead we got:

```ruby
=> 2
# because
sku.quantity.to_f / sku.quantity
=> BigDecimal("1.000000000000000139783503310073358383")
```

Let's be very clear, and force the given SKU properties into BigDecimals when they come into the library. Then we can't make this mistake again!