### PR TITLE
Consider max_quantity when desired exceeds OR EQUALS max_quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # OrderOptimizer Gem Changelog
 
+## 0.5.1 (2021-11-29)
+-  Consider `max_quantity` when desired exceeds OR EQUALS max_quantity
+
 ## 0.5.0 (2021-04-15)
 - Add `maximum_quantity` for SKUs
 

--- a/lib/order_optimizer.rb
+++ b/lib/order_optimizer.rb
@@ -55,7 +55,7 @@ class OrderOptimizer
   def count_and_remainder_for_sku(quantity, sku)
     count, remainder = quantity.divmod(sku.quantity)
 
-    if sku.max_quantity && count * sku.quantity > sku.max_quantity
+    if sku.max_quantity && count * sku.quantity >= sku.max_quantity
       new_count = (sku.max_quantity / sku.quantity).ceil
       remainder = (count - new_count) * sku.quantity
 

--- a/lib/order_optimizer/version.rb
+++ b/lib/order_optimizer/version.rb
@@ -1,3 +1,3 @@
 class OrderOptimizer
-  VERSION = "0.5.0".freeze
+  VERSION = "0.5.1".freeze
 end

--- a/test/order_optimizer_test.rb
+++ b/test/order_optimizer_test.rb
@@ -279,10 +279,10 @@ class OrderOptimizerTest < Minitest::Test
       '10-pack' => { quantity: 10, price_per_sku: 60, max_quantity: 10 }
     )
 
-    order = optimizer.cheapest_order(required_qty: 20)
-    assert_equal 20, order.quantity
-    assert_equal 150, order.total
-    assert_equal({ '10-pack' => 1, '1-pack' => 10 }, order.skus)
+    order = optimizer.cheapest_order(required_qty: 19)
+    assert_equal 19, order.quantity
+    assert_equal 141, order.total
+    assert_equal({ '10-pack' => 1, '1-pack' => 9 }, order.skus)
 
     optimizer = OrderOptimizer.new(
       '1-pack' => { quantity: 1, price_per_sku: 9 },


### PR DESCRIPTION
Previously, this test has a boundary condition that only triggers when the desired quantity is some even multiple of the maximum quantity - e.g. asking for 20, when the max is 10.

If asking for 19 (see test), we get 1x "10-pack" and thus `sku.quantity == max_quantity`. We still want to consider the limit in this case.